### PR TITLE
Updating java wrapper version from 2.4.7 to 2.4.22(AST-140249)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <dependency>
             <groupId>com.checkmarx.ast</groupId>
             <artifactId>ast-cli-java-wrapper</artifactId>
-            <version>2.4.7</version>
+            <version>2.4.22</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
The Java wrapper has been upgraded to version 2.4.22 to remediate vulnerability Cxfa47c4e4-5ef9 in Maven dependency com.fasterxml.jackson.core:jackson-core-2.16.1 ([AST-140249](https://checkmarx.atlassian.net/browse/AST-140249?search_id=fb79b23b-40a5-453a-9451-332871bddb29&referrer=quick-find)). The wrapper now binds to jackson-core 2.21.1, which is a secure version."

[AST-140249]: https://checkmarx.atlassian.net/browse/AST-140249?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ