### PR TITLE
Fixed Maven-org.codehaus.plexus:plexus-utils-3.5.1 vulnerability (AST-144752)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,18 @@
         <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <!-- Override vulnerable transitive dependency from maven-plugin-api:
+                 plexus-utils < 6d780b33 has a Directory Traversal vulnerability (CVE in Expand.extractFile) -->
+            <dependency>
+                <groupId>org.codehaus.plexus</groupId>
+                <artifactId>plexus-utils</artifactId>
+                <version>4.0.2</version>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.apache.maven</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
                 <artifactId>plexus-utils</artifactId>
-                <version>4.0.2</version>
+                <version>4.0.3</version>
             </dependency>
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
## Description

- The fix is to override the transitive **plexus-utils** dependency via dependencyManagement to force a patched version.
- Added a dependencyManagement block to pin it to 4.0.3 (the latest safe version), This forces Maven to use plexus-utils 4.0.3 across the entire dependency tree, overriding the vulnerable 3.5.1 that maven-plugin-api:3.9.6 pulls in transitively.
